### PR TITLE
Set up Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "08:00"
+      timezone: "Asia/Manila"
+    commit-message:
+      prefix: "[actions] "


### PR DESCRIPTION
Configure Dependabot to check for updates to GitHub Actions daily at 08:00 AM Manila time.